### PR TITLE
Update html.go

### DIFF
--- a/html.go
+++ b/html.go
@@ -516,7 +516,7 @@ func (options *Html) Image(out *bytes.Buffer, link []byte, title []byte, alt []b
 		return
 	}
 
-	out.WriteString("<img data-src=\"")
+	out.WriteString("<img src=\"/images/loader.gif\" data-src=\"")
 	options.maybeWriteAbsolutePrefix(out, link)
 	attrEscape(out, link)
 	out.WriteString("\" alt=\"")


### PR DESCRIPTION
fixed the img flash, the default img src is an loading img
blackfriday的markdown解析里的img加上src，并引用一个加载gif图片
